### PR TITLE
chore: tighten Claude Code config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.file_path' | xargs npx prettier --write"
+            "command": "jq -r '.tool_input.file_path' | grep -E '\\.(ts|tsx|js|jsx|css|md|json)$' | xargs -r npx prettier --write"
           }
         ]
       },
@@ -15,7 +15,16 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.file_path' | xargs npx eslint --max-warnings=0"
+            "command": "jq -r '.tool_input.file_path' | grep -E '\\.(ts|tsx|js|jsx)$' | xargs -r npx eslint --max-warnings=0"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path' | grep -qE '\\.(ts|tsx)$' && npx tsc --noEmit"
           }
         ]
       }

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,10 +3,7 @@
     "context7": {
       "type": "stdio",
       "command": "npx",
-      "args": [
-        "-y",
-        "@upstash/context7-mcp"
-      ],
+      "args": ["-y", "@upstash/context7-mcp"],
       "env": {}
     },
     "vercel": {

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,17 @@
+{
+  "mcpServers": {
+    "context7": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@upstash/context7-mcp"
+      ],
+      "env": {}
+    },
+    "vercel": {
+      "type": "http",
+      "url": "https://mcp.vercel.com"
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@ Personal website for Mark Holland. Next.js 16 App Router with Tailwind CSS v4, d
 
 - `npm run dev` - Start dev server
 - `npm run build` - Production build
+- `npm run start` - Start production server (after `build`)
 - `npm run lint` - ESLint with zero warnings allowed (`--max-warnings=0`)
 - `npm run format` - Prettier check
 
@@ -25,6 +26,6 @@ Personal website for Mark Holland. Next.js 16 App Router with Tailwind CSS v4, d
 ## Gotchas
 
 - Node 22.x required (see `engines` in package.json)
-- `patch-package` runs on postinstall - check `patches/` dir for active patches
+- `patch-package` runs on postinstall — no `patches/` dir currently exists, so it's a no-op until one is added
 - Husky pre-commit runs `pretty-quick --staged` and lint
 - ESLint enforces zero warnings - all warnings must be resolved before commit


### PR DESCRIPTION
## Summary
- Scope Prettier/ESLint PostToolUse hooks to supported file types (`.ts/.tsx/.js/.jsx` for ESLint, plus `.css/.md/.json` for Prettier) and add `xargs -r` so unrelated edits no-op instead of erroring.
- Add a `tsc --noEmit` PostToolUse hook so strict TS errors surface during edits, not at `next build` / CI.
- Pin MCP servers (`context7`, `vercel`) in `.mcp.json` at project scope so the same setup follows the repo across machines instead of living in per-user local config.
- Refresh `CLAUDE.md`: add `npm run start` and correct the `patch-package` gotcha (no `patches/` dir currently exists).

## Test plan
- [ ] Edit a `.ts` file via Claude — confirm Prettier, ESLint, and `tsc --noEmit` all run cleanly.
- [ ] Edit a `.md` file — confirm Prettier runs but ESLint/`tsc` no-op.
- [ ] On a fresh clone, run `claude mcp list` — confirm `context7` and `vercel` show up from `.mcp.json` (after approval prompt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)